### PR TITLE
fix: give default items on `aim_*` maps

### DIFF
--- a/cstrike/addons/amxmodx/scripting/ReDeathmatch/ReDM_equip_manager.inc
+++ b/cstrike/addons/amxmodx/scripting/ReDeathmatch/ReDM_equip_manager.inc
@@ -302,6 +302,8 @@ public CBasePlayer_OnSpawnEquip(const player, bool: addDefault, bool: equipGame)
     if (!IsActive())
         return
 
+    SetHookChainArg(3, ATYPE_BOOL, (equipGame = false))
+
     RoundModes_OnSpawnEquip(player)
     ModeVote_OnSpawnEquip(player)
 


### PR DESCRIPTION
problem was in https://github.com/s1lentq/ReGameDLL_CS/blob/942776783b1e6ac87bbe706af61987683819707c/regamedll/dlls/player.cpp#L10158

Blocks processing `game_player_equip` entity with allow to use `GiveDefaultItems()`



fix https://github.com/wopox1337/ReDeathmatch/issues/49